### PR TITLE
Revise proxy to use objects instead of prototypes

### DIFF
--- a/dist/ardrone.js
+++ b/dist/ardrone.js
@@ -29,6 +29,7 @@
         this.name = opts.name;
         this.ardrone = null;
         this.conector = null;
+        this.myself = this;
       }
 
       ARDrone.prototype.commands = function() {
@@ -41,7 +42,7 @@
           ip: this.connection.port.toString()
         });
         this.connector = this.ardrone;
-        this.proxyMethods(Cylon.ARDrone.Commands, this.ardrone, Cylon.Adaptor.ARDrone);
+        this.proxyMethods(Cylon.ARDrone.Commands, this.ardrone, this.myself);
         this.defineAdaptorEvent({
           eventName: 'navdata'
         });

--- a/dist/flight.js
+++ b/dist/flight.js
@@ -25,7 +25,7 @@
         Flight.__super__.constructor.apply(this, arguments);
         this.device = opts.device;
         this.connection = this.device.connection;
-        this.proxyMethods(Cylon.ARDrone.Commands, this.connection, Flight);
+        this.proxyMethods(Cylon.ARDrone.Commands, this.connection, this);
       }
 
       Flight.prototype.commands = function() {

--- a/src/ardrone.coffee
+++ b/src/ardrone.coffee
@@ -20,6 +20,7 @@ namespace "Cylon.Adaptor", ->
       @name = opts.name
       @ardrone = null
       @conector = null
+      @myself = this
 
     commands: -> Cylon.ARDrone.Commands
 
@@ -28,7 +29,7 @@ namespace "Cylon.Adaptor", ->
       @ardrone = new LibARDrone.createClient(ip: @connection.port.toString())
       @connector = @ardrone
 
-      @proxyMethods Cylon.ARDrone.Commands, @ardrone, Cylon.Adaptor.ARDrone
+      @proxyMethods Cylon.ARDrone.Commands, @ardrone, @myself
 
       @defineAdaptorEvent eventName: 'navdata'
       @defineAdaptorEvent eventName: 'landing'

--- a/src/flight.coffee
+++ b/src/flight.coffee
@@ -16,7 +16,7 @@ namespace "Cylon.Driver.ARDrone", ->
       super
       @device = opts.device
       @connection = @device.connection
-      @proxyMethods Cylon.ARDrone.Commands, @connection, Flight
+      @proxyMethods Cylon.ARDrone.Commands, @connection, this
 
     commands: -> Cylon.ARDrone.Commands
 


### PR DESCRIPTION
Revise proxy to attach functions to objects directly instead of their prototypes.
