### PR TITLE
Alias `forward` command and add easier flips

### DIFF
--- a/dist/commands.js
+++ b/dist/commands.js
@@ -13,7 +13,7 @@
   namespace = require('node-namespace');
 
   namespace("Cylon.ARDrone", function() {
-    return this.Commands = ['takeoff', 'land', 'stop', 'up', 'down', 'left', 'right', 'front', 'back', 'clockwise', 'counterClockwise', 'calibrate', 'config', 'animate', 'animateLeds', 'disableEmergency', 'forward', 'frontFlip', 'backFlip', 'leftFlip', 'rightFlip'];
+    return this.Commands = ['takeoff', 'land', 'stop', 'up', 'down', 'left', 'right', 'front', 'back', 'clockwise', 'counterClockwise', 'calibrate', 'config', 'animate', 'animateLeds', 'disableEmergency', 'forward', 'frontFlip', 'backFlip', 'leftFlip', 'rightFlip', 'wave'];
   });
 
 }).call(this);

--- a/dist/flight.js
+++ b/dist/flight.js
@@ -65,6 +65,10 @@
         return this.connection.animate('flipRight', 150);
       };
 
+      Flight.prototype.wave = function() {
+        return this.connection.animate('wave', 750);
+      };
+
       return Flight;
 
     })(Cylon.Basestar);

--- a/src/commands.coffee
+++ b/src/commands.coffee
@@ -38,8 +38,9 @@ namespace "Cylon.ARDrone", ->
 
     # Custom ARDrone commands that we add, mostly aliases for other commands
     'forward', # alias for 'front'
-    'frontFlip', # alias for 'animate("flipAhead", 750)'
-    'backFlip', # alias for 'animate("flipBehind", 750)'
-    'leftFlip', # alias for 'animate("flipLeft", 750)'
-    'rightFlip', # alias for 'animate("flipRight", 750)'
+    'frontFlip', # alias for 'animate("flipAhead", 150)'
+    'backFlip', # alias for 'animate("flipBehind", 150)'
+    'leftFlip', # alias for 'animate("flipLeft", 150)'
+    'rightFlip', # alias for 'animate("flipRight", 150)'
+    'wave' # alias for 'animate("wave", 750)'
   ]

--- a/src/flight.coffee
+++ b/src/flight.coffee
@@ -42,3 +42,6 @@ namespace "Cylon.Driver.ARDrone", ->
 
     rightFlip: ->
       @connection.animate 'flipRight', 150
+
+    wave: ->
+      @connection.animate 'wave', 750


### PR DESCRIPTION
Adds aliased command `forward` to `front` to maintain consistency.

Also adds alias to flip animations:
- `my.drone.frontFlip()`
- `my.drone.backFlip()`
- `my.drone.leftFlip()`
- `my.drone.rightFlip()`
