### PR TITLE
Fixing the drone face tracking

### DIFF
--- a/examples/drone_face_tracking/drone_face_tracking.js
+++ b/examples/drone_face_tracking/drone_face_tracking.js
@@ -10,8 +10,7 @@ Cylon.robot({
 
   devices: [
     { name: 'drone', driver: 'ardrone', connection: 'ardrone' },
-    { name: 'window', driver: 'window', conneciton: 'opencv' },
-    { name: 'opencv', driver: 'opencv', conneciton: 'opencv' }
+    { name: 'window', driver: 'window', connection: 'opencv' }
   ],
 
   work: function(my) {


### PR DESCRIPTION
Fixing misspelling in the window device connection property and removing opencv device since it causes the example to fail.
