### PR TITLE
Update ardrone navigation driver example docs

### DIFF
--- a/examples/drone_nav/drone_nav.js
+++ b/examples/drone_nav/drone_nav.js
@@ -14,6 +14,6 @@ Cylon.robot({
 
   work: function(my) {
     my.drone.config("general:navdata_demo", "TRUE");
-    my.nav.on("update", console.log);
+    my.nav.on("navdata", console.log);
   }
 }).start();

--- a/examples/drone_nav/drone_nav.markdown
+++ b/examples/drone_nav/drone_nav.markdown
@@ -24,7 +24,7 @@ ARDrone's navigation board.
 
       devices: {
         drone: { driver: 'ardrone' },
-        nav: { driver: 'ardroneNav' }
+        nav: { driver: 'ardrone-nav' }
       },
 
 For our robot's work, it's going to enable the nav board's demo mode in the
@@ -33,7 +33,7 @@ drone's config, and log data to the console whenever the nav board emits the
 
       work: function(my) {
         my.drone.config('general:navdata_demo', 'TRUE');
-        my.nav.on('update', console.log);
+        my.nav.on('navdata', console.log);
       }
 
 Simple enough. Now all that's left is to start the robot:

--- a/examples/drone_nav/fluent-drone_nav.js
+++ b/examples/drone_nav/fluent-drone_nav.js
@@ -9,7 +9,7 @@ Cylon
   .device("nav", { driver: "ardroneNav" })
   .on("ready", function(bot) {
     bot.drone.config("general:navdata_demo", "TRUE");
-    bot.nav.on("update", console.log);
+    bot.nav.on("navdata", console.log);
   });
 
 Cylon.start();


### PR DESCRIPTION
Hey, I've recently been taking the `cylon-ardrone` module for a run, it's awesome thanks!

When attempting to add the drone nav stuff in I noticed the example docs are slightly out of date using `ardroneNav` instead of `ardrone-nav` as the device driver name.

Took me a little while to figure it out by finding the example code here, so to save someone else the time thought I'd send a quick patch through :blush:

The docs for the site also need updating http://cylonjs.com/documentation/drivers/ardrone-navigation/ so will investigate sending a patch through to that too

Cheers