### PR TITLE
Adds support for entering emergency mode (cut engines).

### DIFF
--- a/lib/flight.js
+++ b/lib/flight.js
@@ -134,3 +134,13 @@ Flight.prototype.wave = function() {
 Flight.prototype.ftrim = function() {
   return this.connection.ftrim();
 };
+
+/**
+ * Tells the drone to enter emergency mode (cut engines).
+ *
+ * @return {null}
+ * @publish
+ */
+Flight.prototype.enableEmergency = function() {
+  return this.connection.ardrone._ref.emergency = true;
+};

--- a/spec/lib/flight.spec.js
+++ b/spec/lib/flight.spec.js
@@ -88,4 +88,11 @@ describe("Cylon.Drivers.ARDrone.Flight", function() {
       });
     });
   });
+
+  describe("#enableEmergency", function() {
+    it("tells the drone to enter emergency mode (cut engines)", function() {
+      driver.enableEmergency();
+      expect(driver.connection.ardrone._ref.emergency).to.equal(true);
+    });
+  });
 });


### PR DESCRIPTION
This implements triggering emergency mode (see issue #25 ), causing the drone to cut its engines. Physical experimentation showed that it works.

However, I was unable to write a suitable test, maybe someone with more experience with [mocha](http://mochajs.org/) and [sinon](http://sinonjs.org/) can help out? I look forward to learning from the solution as I am an avid tester but less familiar with these particular implementations.
I wrote a failing test. I put it outside the proxies describe block as I don't think the enableEmergency() method should be considered a proxied method. Rather it sets a variable on the underlying drone connection. Correct me if I'm wrong in this assumption.

Cheers!

--m
